### PR TITLE
Refactor social login into service with validation

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,5 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Moved social login DB logic into `UserService` with provider whitelist and uniqueness check.
+- Added `UserService.social_login` method and updated API endpoint to use it.


### PR DESCRIPTION
## Summary
- centralize social login in `UserService` with provider normalization
- enforce `(social_provider, social_id)` uniqueness and add whitelist
- update `/social-login` endpoint to use the new service

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5b4dc1fe883238e517b3fe878aa75