### PR TITLE
Handle apiFetch network errors

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Wrapped `apiFetch` network request in a try/catch to log errors, notify via `useNotifications`, and rethrow descriptive network errors.


### PR DESCRIPTION
## Summary
- handle network failures in `apiFetch` by wrapping the request in try/catch, logging, notifying, and rethrowing a descriptive error
- document network error handling in AI changes log

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck` *(fails: TypeScript errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b501a4cc8323a6085323992ffdb4