### PR TITLE
Persist auth token in session storage

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Persisted auth token and role ID to `sessionStorage`, added logout clearing logic, and noted security considerations against using `localStorage`.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ When the API schema changes:
 The admin build and the Telegram bot both read the specification from `/openapi.json`.
 Removing the now redundant `admin/openapi/openapi.json` prevents the specification
 from diverging in the future.
+
+## Security considerations
+
+Authentication tokens for the admin panel are stored in `sessionStorage`. This keeps credentials scoped to the current browser tab and clears them when the session ends. Avoid using `localStorage` for long-term persistence, since data there survives browser restarts and is more vulnerable to theft via cross-site scripting.

--- a/admin/src/store/auth.ts
+++ b/admin/src/store/auth.ts
@@ -3,10 +3,11 @@ import { create } from 'zustand';
 /**
  * Zustand store for authentication state.  Holds the current JWT
  * token and the associated roleId.  Components can subscribe to
- * these values via the `useAuth` hook.  In later phases this
- * implementation may be extended to persist tokens to localStorage
- * or cookies.  For security reasons, keeping the token in memory
- * reduces exposure surface (it disappears on page refresh).
+ * these values via the `useAuth` hook. Tokens are mirrored to
+ * `sessionStorage` so that refreshing the page preserves the
+ * session while still clearing credentials when the tab closes.
+ * Avoid storing tokens in `localStorage` because data persists
+ * indefinitely and can be exfiltrated by XSS.
  */
 interface AuthState {
   token: string | null;
@@ -15,9 +16,36 @@ interface AuthState {
   logout: () => void;
 }
 
+const TOKEN_KEY = 'authToken';
+const ROLE_KEY = 'authRoleId';
+
+const loadToken = (): { token: string | null; roleId: number | null } => {
+  if (typeof sessionStorage === 'undefined') {
+    return { token: null, roleId: null };
+  }
+  const token = sessionStorage.getItem(TOKEN_KEY);
+  const roleIdStr = sessionStorage.getItem(ROLE_KEY);
+  return { token, roleId: roleIdStr ? Number(roleIdStr) : null };
+};
+
 export const useAuth = create<AuthState>((set) => ({
-  token: null,
-  roleId: null,
-  setToken: (token: string, roleId: number | null) => set({ token, roleId }),
-  logout: () => set({ token: null, roleId: null }),
+  ...loadToken(),
+  setToken: (token: string, roleId: number | null) => {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.setItem(TOKEN_KEY, token);
+      if (roleId !== null) {
+        sessionStorage.setItem(ROLE_KEY, roleId.toString());
+      } else {
+        sessionStorage.removeItem(ROLE_KEY);
+      }
+    }
+    set({ token, roleId });
+  },
+  logout: () => {
+    if (typeof sessionStorage !== 'undefined') {
+      sessionStorage.removeItem(TOKEN_KEY);
+      sessionStorage.removeItem(ROLE_KEY);
+    }
+    set({ token: null, roleId: null });
+  },
 }));


### PR DESCRIPTION
## Summary
- persist auth token and role ID in sessionStorage and hydrate store on load
- add logout routine clearing sessionStorage and Zustand state
- document sessionStorage security considerations in README

## Testing
- `npm --prefix admin test` *(fails: No test files found)*
- `npm --prefix admin run lint` *(fails: ESLint couldn't find a config file)*
- `npm --prefix admin run typecheck` *(fails: multiple existing TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b511fc088323bc821c0a83c83679