### PR TITLE
feat: use generated API types

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Replaced custom admin API interfaces with generated types and updated regeneration docs.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ When the API schema changes:
 1. Replace or edit `openapi.json` in the repository root.
 2. Regenerate frontend types:
    ```bash
-   npm --prefix admin run gen:api
+   cd admin
+   npm run gen:api
    ```
 3. Regenerate bot types:
    ```bash

--- a/admin/src/api/audit.ts
+++ b/admin/src/api/audit.ts
@@ -1,22 +1,10 @@
 import { apiFetch } from './client';
+import type { operations } from './types.gen';
 
-/** Query parameters for retrieving audit logs. */
-export interface AuditQueryParams {
-  user_id?: number | null;
-  object_type?: string | null;
-  action?: string | null;
-  start_date?: string | null;
-  end_date?: string | null;
-  limit?: number;
-  offset?: number;
-}
-
-/** The audit log API returns arbitrary JSON objects describing actions taken
- * within the system.  Each record typically includes fields such as
- * ``id``, ``user_id``, ``object_type``, ``object_id``, ``action`` and
- * ``timestamp``, but the schema is not formally defined.  We use a
- * catch-all type here and let consumers handle fields dynamically. */
-export type AuditLog = Record<string, unknown>;
+export type AuditQueryParams =
+  operations['list_audit_logs_api_v1_audit_logs_get']['parameters']['query'];
+export type AuditLog =
+  operations['list_audit_logs_api_v1_audit_logs_get']['responses'][200]['content']['application/json'][number];
 
 /**
  * Retrieve a list of audit logs filtered by optional parameters.

--- a/admin/src/api/auth.ts
+++ b/admin/src/api/auth.ts
@@ -1,14 +1,11 @@
 import { apiFetch } from './client';
+import type { operations } from './types.gen';
 
-export interface LoginRequest {
-  email: string;
-  password: string;
-}
+export type LoginRequest =
+  operations['login_user_api_v1_users_login_post']['requestBody']['content']['application/json'];
 
-export interface LoginResponse {
-  token: string;
-  role_id?: number;
-}
+export type LoginResponse =
+  operations['login_user_api_v1_users_login_post']['responses'][200]['content']['application/json'];
 
 /**
  * Authenticate the user with the backend.  On success, returns a JWT

--- a/admin/src/api/bookings.ts
+++ b/admin/src/api/bookings.ts
@@ -1,27 +1,12 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/**
- * Representation of a booking returned by the API.  Matches the
- * BookingRead schema from the OpenAPI spec.  Some fields may be
- * nullable.
- */
-export interface Booking {
-  id: number;
-  user_id: number;
-  event_id: number;
-  group_size: number;
-  status: string;
-  created_at: string;
-  is_paid?: boolean | null;
-  is_attended?: boolean | null;
-  group_names?: string[] | null;
-}
-
-/** Schema for creating a booking.  Matches BookingCreate. */
-export interface BookingCreate {
-  group_size: number;
-  group_names?: string[] | null;
-}
+export type Booking = components['schemas']['BookingRead'];
+export type BookingCreate = components['schemas']['BookingCreate'];
+export type WaitlistEntry =
+  operations['list_event_waitlist_api_v1_events__event_id__waitlist_get']['responses'][200]['content']['application/json'] extends Array<infer T>
+    ? T
+    : unknown;
 
 /**
  * Fetch bookings for a specific event via GET /api/v1/events/{event_id}/bookings.
@@ -72,18 +57,6 @@ export async function toggleAttendance(
   return apiFetch<Booking>(`/api/v1/bookings/${bookingId}/toggle-attendance`, {
     method: 'POST',
   });
-}
-
-/**
- * Representation of a waitlist entry returned by the API.  The
- * endpoint does not have an explicit schema definition, so we
- * declare it here.
- */
-export interface WaitlistEntry {
-  id: number;
-  user_id: number;
-  position: number;
-  created_at: string;
 }
 
 /**

--- a/admin/src/api/events.ts
+++ b/admin/src/api/events.ts
@@ -1,62 +1,11 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/**
- * Representation of an event returned by the API.  Dates are
- * represented as ISO strings; UI components can convert them to
- * localized formats when rendering.
- */
-export interface Event {
-  id: number;
-  title: string;
-  description?: string | null;
-  start_time: string;
-  duration_minutes: number;
-  max_participants: number;
-  is_paid: boolean;
-}
-
-export interface EventsQueryParams {
-  limit?: number;
-  offset?: number;
-  sort_by?: string;
-  order?: 'asc' | 'desc';
-  is_paid?: boolean;
-  date_from?: string;
-  date_to?: string;
-}
-
-/**
- * Payload for creating a new event.  Matches the EventCreate schema
- * defined in the OpenAPI spec.  All fields are required except
- * description.
- */
-export interface EventCreate {
-  title: string;
-  description?: string | null;
-  /** ISO 8601 datetime string when the event starts */
-  start_time: string;
-  /** Duration in minutes */
-  duration_minutes: number;
-  /** Maximum number of participants */
-  max_participants: number;
-  /** Whether the event is paid */
-  is_paid: boolean;
-}
-
-/**
- * Payload for updating an existing event.  All fields are optional
- * because the server will merge undefined values with the existing
- * record.  A null value will explicitly clear the field on the
- * server.  Matches the EventUpdate schema from the spec.
- */
-export interface EventUpdate {
-  title?: string | null;
-  description?: string | null;
-  start_time?: string | null;
-  duration_minutes?: number | null;
-  max_participants?: number | null;
-  is_paid?: boolean | null;
-}
+export type Event = components['schemas']['EventRead'];
+export type EventsQueryParams =
+  NonNullable<operations['list_events_api_v1_events__get']['parameters']['query']>;
+export type EventCreate = components['schemas']['EventCreate'];
+export type EventUpdate = components['schemas']['EventUpdate'];
 
 /**
  * Create a new event via POST /api/v1/events/.
@@ -117,13 +66,14 @@ export async function duplicateEvent(
  * not currently include total count, so callers must handle their
  * own pagination logic.
  */
-export async function getEvents(params: EventsQueryParams): Promise<Event[]> {
+export async function getEvents(params: EventsQueryParams = {}): Promise<Event[]> {
   const query = new URLSearchParams();
   if (params.limit !== undefined) query.set('limit', String(params.limit));
   if (params.offset !== undefined) query.set('offset', String(params.offset));
   if (params.sort_by) query.set('sort_by', params.sort_by);
   if (params.order) query.set('order', params.order);
-  if (params.is_paid !== undefined) query.set('is_paid', String(params.is_paid));
+  if (params.is_paid !== undefined && params.is_paid !== null)
+    query.set('is_paid', String(params.is_paid));
   if (params.date_from) query.set('date_from', params.date_from);
   if (params.date_to) query.set('date_to', params.date_to);
   const qs = query.toString();

--- a/admin/src/api/faqs.ts
+++ b/admin/src/api/faqs.ts
@@ -1,52 +1,17 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/** Represents a frequently asked question entry. */
-export interface Faq {
-  id: number;
-  question_short: string;
-  question_full: string | null;
-  answer: string;
-  attachments: string[] | null;
-  position: number;
-  created_at: string;
-  updated_at: string;
-}
-
-/** Schema for creating a new FAQ entry.  Only question_short and
- * answer are required; other fields are optional. */
-export interface FaqCreate {
-  question_short: string;
-  question_full?: string | null;
-  answer: string;
-  attachments?: string[] | null;
-  position?: number | null;
-}
-
-/** Schema for updating an existing FAQ entry.  All fields are
- * optional; omitted fields are left unchanged. */
-export interface FaqUpdate {
-  question_short?: string | null;
-  question_full?: string | null;
-  answer?: string | null;
-  attachments?: string[] | null;
-  position?: number | null;
-}
-
-/** Query parameters for listing FAQs. */
-export interface FaqQueryParams {
-  limit?: number;
-  offset?: number;
-  sort_by?: string | null;
-  order?: string | null;
-}
+export type Faq = components['schemas']['FAQRead'];
+export type FaqCreate = components['schemas']['FAQCreate'];
+export type FaqUpdate = components['schemas']['FAQUpdate'];
+export type FaqQueryParams =
+  NonNullable<operations['list_faqs_api_v1_faqs__get']['parameters']['query']>;
 
 /** Fetch a paginated list of FAQ entries. */
 export async function getFaqs(params: FaqQueryParams = {}): Promise<Faq[]> {
   const search = new URLSearchParams();
   if (params.limit !== undefined) search.set('limit', String(params.limit));
   if (params.offset !== undefined) search.set('offset', String(params.offset));
-  if (params.sort_by) search.set('sort_by', params.sort_by);
-  if (params.order) search.set('order', params.order);
   const query = search.toString();
   const url = `/api/v1/faqs/${query ? `?${query}` : ''}`;
   return apiFetch<Faq[]>(url);

--- a/admin/src/api/mailings.ts
+++ b/admin/src/api/mailings.ts
@@ -1,61 +1,14 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/**
- * Interfaces describing the shape of mailing data returned from the API.
- * The backend returns ISO timestamps for created_at and scheduled_at fields
- * and allows an arbitrary JSON object for filters.  When creating or
- * updating a mailing the frontend may supply a subset of these fields.
- */
-export interface Mailing {
-  id: number;
-  created_by: number;
-  title: string;
-  content: string;
-  /** Criteria to select recipients, stored as an arbitrary object */
-  filters: Record<string, unknown> | null;
-  /** ISO 8601 datetime when the mailing is scheduled to send, or null */
-  scheduled_at: string | null;
-  /** ISO 8601 datetime when the mailing was created */
-  created_at: string;
-  /** List of messenger channels to send through (e.g. ['telegram']) */
-  messengers: string[] | null;
-}
-
-/** Schema for creating a new mailing.  Only title and content are required. */
-export interface MailingCreate {
-  title: string;
-  content: string;
-  filters?: Record<string, unknown> | null;
-  scheduled_at?: string | null;
-  messengers?: string[] | null;
-}
-
-/** Schema for updating an existing mailing.  All fields are optional. */
-export interface MailingUpdate {
-  title?: string | null;
-  content?: string | null;
-  filters?: Record<string, unknown> | null;
-  scheduled_at?: string | null;
-  messengers?: string[] | null;
-}
-
-/** Shape of an individual mailing log entry returned by the API. */
-export interface MailingLog {
-  id: number;
-  mailing_id: number;
-  user_id: number;
-  status: string;
-  error_message: string | null;
-  sent_at: string;
-}
-
-/** Parameters for querying the list of mailings.  All fields are optional. */
-export interface MailingsQueryParams {
-  limit?: number;
-  offset?: number;
-  sort_by?: string | null;
-  order?: string | null;
-}
+export type Mailing = components['schemas']['MailingRead'];
+export type MailingCreate = components['schemas']['MailingCreate'];
+export type MailingUpdate = components['schemas']['MailingUpdate'];
+export type MailingLog = components['schemas']['MailingLogRead'];
+export type MailingsQueryParams =
+  NonNullable<operations['list_mailings_api_v1_mailings__get']['parameters']['query']>;
+export type MailingLogsQueryParams =
+  NonNullable<operations['get_logs_api_v1_mailings__mailing_id__logs_get']['parameters']['query']>;
 
 /**
  * Retrieve a list of mailings.  Results may be paginated and sorted via
@@ -110,7 +63,7 @@ export async function sendMailing(id: number): Promise<number> {
 /** Retrieve delivery logs for a mailing.  Results may be paginated. */
 export async function getMailingLogs(
   id: number,
-  params: { limit?: number; offset?: number } = {},
+  params: MailingLogsQueryParams = {},
 ): Promise<MailingLog[]> {
   const search = new URLSearchParams();
   if (params.limit !== undefined) search.set('limit', String(params.limit));

--- a/admin/src/api/messages.ts
+++ b/admin/src/api/messages.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from './client';
+import type { operations } from './types.gen';
 
 /**
  * The messages API manages bot message templates keyed by a string.
@@ -7,7 +8,8 @@ import { apiFetch } from './client';
  * contains ``content`` (string) and optional ``buttons`` (array).
  */
 
-export type BotMessage = Record<string, unknown>;
+export type BotMessage =
+  operations['get_message_api_v1_messages__key__get']['responses'][200]['content']['application/json'];
 
 /** List all bot message templates.  Returns an array of objects. */
 export async function getMessages(): Promise<BotMessage[]> {

--- a/admin/src/api/payments.ts
+++ b/admin/src/api/payments.ts
@@ -1,43 +1,9 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/**
- * Representation of a payment returned by the API.  Matches the
- * ``PaymentRead`` schema in the OpenAPI spec.  Not all properties
- * are strictly typed here; unknown properties are preserved via the
- * index signature.
- */
-export interface Payment {
-  id: number;
-  user_id?: number;
-  event_id?: number | null;
-  amount: number;
-  currency: string;
-  description?: string | null;
-  provider?: string | null;
-  status?: string | null;
-  external_id?: string | null;
-  confirmed_by?: number | null;
-  confirmed_at?: string | null;
-  created_at: string;
-  updated_at?: string | null;
-  [key: string]: unknown;
-}
-
-/**
- * Query parameters accepted by the list payments endpoint.  All
- * parameters are optional.  See the OpenAPI spec for detailed
- * semantics of each filter.  ``status`` expects raw API values
- * (pending/success/etc.).  ``provider`` expects yookassa/support/cash.
- */
-export interface PaymentsQueryParams {
-  event_id?: number;
-  provider?: string;
-  status?: string;
-  sort_by?: string;
-  order?: 'asc' | 'desc';
-  limit?: number;
-  offset?: number;
-}
+export type Payment = components['schemas']['PaymentRead'];
+export type PaymentsQueryParams =
+  NonNullable<operations['list_payments_api_v1_payments__get']['parameters']['query']>;
 
 /**
  * Fetch a list of payments with optional filters, sorting and
@@ -45,15 +11,18 @@ export interface PaymentsQueryParams {
  * currently does not return a total count; pagination must be
  * inferred by comparing returned length with the requested limit.
  */
-export async function getPayments(params: PaymentsQueryParams): Promise<Payment[]> {
+export async function getPayments(params: PaymentsQueryParams = {}): Promise<Payment[]> {
   const query = new URLSearchParams();
-  if (params.event_id !== undefined) query.set('event_id', String(params.event_id));
+  if (params.event_id !== undefined && params.event_id !== null)
+    query.set('event_id', String(params.event_id));
   if (params.provider) query.set('provider', params.provider);
-  if (params.status) query.set('status_param', params.status);
+  if (params.status_param) query.set('status_param', params.status_param);
   if (params.sort_by) query.set('sort_by', params.sort_by);
   if (params.order) query.set('order', params.order);
-  if (params.limit !== undefined) query.set('limit', String(params.limit));
-  if (params.offset !== undefined) query.set('offset', String(params.offset));
+  if (params.limit !== undefined && params.limit !== null)
+    query.set('limit', String(params.limit));
+  if (params.offset !== undefined && params.offset !== null)
+    query.set('offset', String(params.offset));
   const qs = query.toString();
   const url = qs ? `/api/v1/payments/?${qs}` : '/api/v1/payments/';
   return apiFetch<Payment[]>(url);

--- a/admin/src/api/reviews.ts
+++ b/admin/src/api/reviews.ts
@@ -1,27 +1,9 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/** Represents a user review for an event. */
-export interface Review {
-  id: number;
-  user_id: number;
-  event_id: number;
-  rating: number;
-  comment: string | null;
-  approved: boolean;
-  moderated_by: number | null;
-  created_at: string;
-}
-
-/** Query parameters for listing reviews. */
-export interface ReviewsQueryParams {
-  event_id?: number | null;
-  user_id?: number | null;
-  approved?: boolean | null;
-  limit?: number;
-  offset?: number;
-  sort_by?: string | null;
-  order?: string | null;
-}
+export type Review = components['schemas']['ReviewRead'];
+export type ReviewsQueryParams =
+  operations['list_reviews_api_v1_reviews_get']['parameters']['query'];
 
 /** Fetch a paginated list of reviews with optional filters. */
 export async function getReviews(params: ReviewsQueryParams = {}): Promise<Review[]> {

--- a/admin/src/api/roles.ts
+++ b/admin/src/api/roles.ts
@@ -1,39 +1,14 @@
 import { apiFetch } from './client';
+import type { operations } from './types.gen';
 
-/**
- * Representation of a role returned by the API.  Roles have an id,
- * name and optional permissions payload.  The shape of ``permissions``
- * is not strictly defined in the spec and may be a JSON object or
- * array of strings.  Additional fields may be returned by the
- * backend in the future.
- */
-export interface Role {
-  id: number;
-  name: string;
-  permissions?: unknown;
-  [key: string]: unknown;
-}
-
-/**
- * Payload for creating a new role.  The ``name`` field is required
- * and should be unique.  ``permissions`` may be provided as an
- * array of strings describing the allowed actions.
- */
-export interface RoleCreate {
-  name: string;
-  permissions?: string[];
-}
-
-/**
- * Payload for updating an existing role.  Any of the fields may
- * optionally be specified.  Undefined values are omitted from the
- * request body so that only explicitly provided fields are
- * modified.
- */
-export interface RoleUpdate {
-  name?: string;
-  permissions?: string[];
-}
+export type Role =
+  operations['list_roles_api_v1_roles__get']['responses'][200]['content']['application/json'][number];
+export type RoleCreate =
+  operations['create_role_api_v1_roles__post']['requestBody']['content']['application/json'];
+export type RoleUpdate =
+  operations['update_role_api_v1_roles__role_id__put']['requestBody']['content']['application/json'];
+export type RoleAssignPayload =
+  operations['assign_role_api_v1_roles_assign_post']['requestBody']['content']['application/json'];
 
 /**
  * Fetch a list of roles from the backend.  Only super
@@ -82,10 +57,6 @@ export async function deleteRole(id: number): Promise<void> {
  * backend returns no content on success.  Only super
  * administrators may assign roles.
  */
-export interface RoleAssignPayload {
-  user_id: number;
-  role_id: number;
-}
 export async function assignRole(payload: RoleAssignPayload): Promise<void> {
   await apiFetch<void>('/api/v1/roles/assign', {
     method: 'POST',

--- a/admin/src/api/settings.ts
+++ b/admin/src/api/settings.ts
@@ -1,15 +1,8 @@
 import { apiFetch } from './client';
+import type { operations } from './types.gen';
 
-/**
- * Represents a single application setting.  The backend stores settings
- * as key/value pairs with an associated type.  Keys may be namespaced
- * (e.g. ``booking.waitlist_delay``) but are returned as a flat list.
- */
-export interface Setting {
-  key: string;
-  value: unknown;
-  type: string;
-}
+export type Setting =
+  operations['list_settings_api_v1_settings__get']['responses'][200]['content']['application/json'][number];
 
 /** Fetch all settings.  Only super administrators can access this endpoint. */
 export async function getSettings(): Promise<Setting[]> {

--- a/admin/src/api/statistics.ts
+++ b/admin/src/api/statistics.ts
@@ -1,24 +1,8 @@
 import { apiFetch } from './client';
+import type { operations } from './types.gen';
 
-/**
- * Shape of the statistics overview returned by the backend.  The
- * backend returns counts of various entities and total revenue.
- * Additional fields may be added in the future without breaking
- * existing consumers because TypeScript treats unspecified keys as
- * optional.  We use an index signature to allow unknown keys.
- */
-export interface StatisticsOverview {
-  users_count?: number;
-  events_count?: number;
-  bookings_count?: number;
-  payments_count?: number;
-  reviews_count?: number;
-  support_tickets_total?: number;
-  support_tickets_open?: number;
-  waitlist_count?: number;
-  total_revenue?: number;
-  [key: string]: number | undefined;
-}
+export type StatisticsOverview =
+  operations['statistics_overview_api_v1_statistics_overview_get']['responses'][200]['content']['application/json'];
 
 /**
  * Fetch global statistics overview from the backend.  Uses the

--- a/admin/src/api/support.ts
+++ b/admin/src/api/support.ts
@@ -1,58 +1,14 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/**
- * Represents a support ticket without its message thread.  Status
- * values are strings such as 'open', 'in_progress', 'resolved'
- * and 'closed'.  Only administrators can view all tickets.
- */
-export interface SupportTicket {
-  id: number;
-  user_id: number;
-  subject: string | null;
-  status: string;
-  created_at: string;
-  updated_at: string;
-}
-
-/** Input schema for creating a support ticket.  Users supply a
- * subject and initial message content. */
-export interface SupportTicketCreate {
-  subject: string;
-  content: string;
-}
-
-/** Input schema for updating the status of a ticket. */
-export interface SupportTicketUpdate {
-  status: string;
-}
-
-/** Represents an individual message on a ticket.  Sender_role
- * identifies whether the message was authored by a user or admin. */
-export interface SupportMessage {
-  id: number;
-  ticket_id: number;
-  content: string;
-  created_at: string;
-  sender_role: string;
-  user_id?: number | null;
-  admin_id?: number | null;
-  attachments?: string[] | null;
-}
-
-/** Composite return type for ticket details and its messages. */
-export interface TicketWithMessages {
-  ticket: SupportTicket;
-  messages: SupportMessage[];
-}
-
-/** Query parameters for listing tickets. */
-export interface TicketsQueryParams {
-  status?: string | null;
-  limit?: number;
-  offset?: number;
-  sort_by?: string | null;
-  order?: string | null;
-}
+export type SupportTicket = components['schemas']['SupportTicketRead'];
+export type SupportTicketCreate = components['schemas']['SupportTicketCreate'];
+export type SupportTicketUpdate = components['schemas']['SupportTicketUpdate'];
+export type SupportMessage = components['schemas']['SupportMessageRead'];
+export type SupportMessageCreate = components['schemas']['SupportMessageCreate'];
+export type TicketWithMessages = components['schemas']['TicketWithMessages'];
+export type TicketsQueryParams =
+  NonNullable<operations['list_tickets_api_v1_support_tickets_get']['parameters']['query']>;
 
 /**
  * List support tickets visible to the current user.  Administrators can
@@ -94,7 +50,7 @@ export async function getTicketWithMessages(id: number): Promise<TicketWithMessa
 /** Reply to a support ticket.  Returns the created message. */
 export async function replyToTicket(
   id: number,
-  data: { content: string; attachments?: string[] | null },
+  data: SupportMessageCreate,
 ): Promise<SupportMessage> {
   return apiFetch<SupportMessage>(`/api/v1/support/tickets/${id}/reply`, {
     method: 'POST',
@@ -103,9 +59,12 @@ export async function replyToTicket(
 }
 
 /** Update the status of a support ticket. */
-export async function updateTicketStatus(id: number, status: string): Promise<SupportTicket> {
+export async function updateTicketStatus(
+  id: number,
+  data: SupportTicketUpdate,
+): Promise<SupportTicket> {
   return apiFetch<SupportTicket>(`/api/v1/support/tickets/${id}/status`, {
     method: 'PUT',
-    body: JSON.stringify({ status }),
+    body: JSON.stringify(data),
   });
 }

--- a/admin/src/api/users.ts
+++ b/admin/src/api/users.ts
@@ -1,51 +1,10 @@
 import { apiFetch } from './client';
+import type { components, operations } from './types.gen';
 
-/**
- * Representation of a user returned by the API.  This matches the
- * ``UserRead`` schema from the OpenAPI spec.  Additional fields
- * such as ``disabled`` or ``role_id`` may be present but are
- * optional on the frontend.  Whenever the backend adds new
- * properties they will be surfaced here automatically via index
- * signature.
- */
-export interface User {
-  id: number;
-  email?: string | null;
-  full_name?: string | null;
-  disabled?: boolean | null;
-  role_id?: number | null;
-  [key: string]: unknown;
-}
-
-/**
- * Payload for creating a new user.  Administrators should provide
- * ``email`` and ``password``.  ``full_name`` is optional.  Social
- * providers may omit the password but supply ``social_provider`` and
- * ``social_id``.  See ``UserCreate`` schema for details.  For the
- * admin panel we limit creation to email/password based users.
- */
-export interface UserCreate {
-  email: string;
-  password: string;
-  full_name?: string | null;
-  disabled?: boolean;
-  role_id?: number | null;
-}
-
-/**
- * Payload for updating an existing user.  All fields are optional.
- * When a property is undefined it will not be sent to the server
- * (therefore no change).  Setting a property to null will clear it
- * on the backend if supported.  The ``role_id`` field will update
- * the user's role via the RoleService.
- */
-export interface UserUpdate {
-  email?: string | null;
-  password?: string | null;
-  full_name?: string | null;
-  disabled?: boolean | null;
-  role_id?: number | null;
-}
+export type User = components['schemas']['UserRead'];
+export type UserCreate = components['schemas']['UserCreate'];
+export type UserUpdate =
+  operations['update_user_api_v1_users__user_id__put']['requestBody']['content']['application/json'];
 
 /**
  * Fetch a list of users from the backend.  The API currently


### PR DESCRIPTION
## Summary
- refactor admin API modules to consume OpenAPI-generated types
- document regenerating API types via `npm run gen:api`

## Testing
- `npm --prefix admin test` *(fails: No test files found)*
- `npm --prefix admin run lint` *(fails: ESLint couldn't find config)*
- `npm --prefix admin run typecheck` *(fails: multiple type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b50c04948323a3b2e90b1849aef9