### PR TITLE
Implement Telegram request retry backoff

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -1,6 +1,7 @@
 # AI Changes Log
 
 ## [Unreleased]
+- Implemented exponential backoff with jitter and `Retry-After` handling for Telegram API requests.
 - Removed duplicated `admin/openapi/openapi.json` and pointed admin type generation at root `openapi.json`.
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.


### PR DESCRIPTION
## Summary
- Add retry tracking and exponential backoff with jitter for Telegram API requests
- Respect Retry-After headers and reset backoff on successful responses
- Route all Telegram HTTP calls through a common helper

## Testing
- `python -m py_compile telegram_event_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5b516acb08323abe054df5ee6bb4b