### PR TITLE
Expire stale user states in Telegram bot

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Added timestamped user state management with automatic TTL cleanup and optional timeout notifications.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ When the API schema changes:
 The admin build and the Telegram bot both read the specification from `/openapi.json`.
 Removing the now redundant `admin/openapi/openapi.json` prevents the specification
 from diverging in the future.
+
+## Telegram bot configuration
+
+The bot supports optional environment variables to manage temporary per-user states:
+
+- `USER_STATE_TTL`: Time-to-live in seconds for entries in the internal user state
+  cache. Entries older than this value are discarded. Default is `300` seconds.
+- `USER_STATE_TIMEOUT_MESSAGE`: If set, this message is sent to users whose state
+  expires due to inactivity.


### PR DESCRIPTION
## Summary
- track a timestamp with each `user_states` entry and clean up old entries after a TTL
- optionally notify users when their interaction timed out
- document new environment variables for state TTL and timeout message

## Testing
- `python -m py_compile telegram_event_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5b52664688323808cf6d705abe57f