### PR TITLE
Improve API error handling and bot fallbacks

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Implemented structured API error handling and updated bot handlers to send friendly fallback messages.


### PR DESCRIPTION
## Summary
- Return structured `(data, error)` tuples from `EventPlannerAPI._request` and propagate through all API methods
- Add friendly error handling in Telegram bot handlers for registration, cancellations, payments and more
- Document new behavior in `AI-CHANGES.MD`

## Testing
- `python -m py_compile event_planner_api.py telegram_event_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c5b52ad16883238fbbff73aa2f873c