### PR TITLE
Send menu prompt with keyboard in single message

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Combined menu prompt and keyboard into a single sendMessage call by adding optional `reply_markup` to `_send_message` and simplifying `_send_main_menu`.


### PR DESCRIPTION
## Summary
- allow `_send_message` to accept `reply_markup`
- send main menu prompt and keyboard in one `sendMessage` call

## Testing
- `python -m py_compile telegram_event_bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c5b54fde508323b018ce8d45a3eb33