### PR TITLE
feat(admin): notify and redirect on role guard failure

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,7 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Enhanced `RoleGuard` to redirect unauthorised users to `/login` while
+  displaying "Access denied" message and notification.
+- Added unit test for `RoleGuard` and testing dependency
+  `@testing-library/react`.

--- a/admin/package.json
+++ b/admin/package.json
@@ -14,24 +14,25 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@tanstack/react-router": "^1.10.0",
+    "@hookform/resolvers": "^3.1.5",
     "@tanstack/react-query": "^4.36.1",
+    "@tanstack/react-router": "^1.10.0",
     "@tanstack/react-table": "^8.10.5",
     "classnames": "^2.3.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.46.0",
     "shadcn-ui": "^0.6.0",
-    "zustand": "^4.5.2",
-    "zod": "^3.23.8"
-    ,
-    "@hookform/resolvers": "^3.1.5"
+    "zod": "^3.23.8",
+    "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@testing-library/react": "^14.2.1",
     "@types/react": "^18.2.20",
     "@types/react-dom": "^18.2.10",
     "@vitejs/plugin-react": "^4.1.0",
     "autoprefixer": "^10.4.16",
+    "jsdom": "^24.0.0",
     "openapi-typescript": "^6.7.0",
     "playwright": "^1.41.2",
     "postcss": "^8.4.31",
@@ -40,5 +41,4 @@
     "vite": "^4.5.0",
     "vitest": "^0.34.0"
   }
-  
 }

--- a/admin/src/components/RoleGuard.test.tsx
+++ b/admin/src/components/RoleGuard.test.tsx
@@ -1,0 +1,40 @@
+/** @vitest-environment jsdom */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import { withRoleGuard } from './RoleGuard';
+
+// Mock authentication hook to return low privileged role
+vi.mock('../store/auth', () => ({
+  useAuth: () => ({ roleId: 3, token: 'fake' }),
+}));
+
+// Mock notifications store
+const addNotification = vi.fn();
+vi.mock('../store/notifications', () => ({
+  useNotifications: () => ({ addNotification }),
+}));
+
+// Mock navigate hook
+const navigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => navigate,
+}));
+
+describe('withRoleGuard', () => {
+  it('redirects and notifies when role is below required', async () => {
+    const Protected = () => <div>Protected content</div>;
+    const Guarded = withRoleGuard(Protected, 1);
+    const { getByText } = render(<Guarded />);
+
+    // Ensure side effects executed
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith({ to: '/login' });
+      expect(addNotification).toHaveBeenCalledWith('Access denied', 'error');
+    });
+
+    // Access denied message rendered
+    getByText('Access denied');
+  });
+});

--- a/admin/src/components/RoleGuard.tsx
+++ b/admin/src/components/RoleGuard.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useAuth } from '../store/auth';
 import { useNavigate } from '@tanstack/react-router';
+import { useNotifications } from '../store/notifications';
 
 /**
  * Higher‑order component that protects a page based on the user's role.
@@ -21,6 +22,7 @@ export function withRoleGuard<P>(
   const Guarded: React.FC<P> = (props) => {
     const { roleId, token } = useAuth();
     const navigate = useNavigate();
+    const { addNotification } = useNotifications();
     // Determine if the user lacks sufficient privileges.  Lower
     // numbers are more privileged (1 = super admin).  We compute
     // this outside of the effect so that hooks are not called
@@ -28,15 +30,16 @@ export function withRoleGuard<P>(
     const unauthorized =
       requiredRole !== undefined && (roleId == null || roleId > requiredRole);
 
-    // When the user is unauthorised, redirect them to the home page.
+    // When the user is unauthorised, notify and redirect them to the login page.
     React.useEffect(() => {
       if (unauthorized) {
-        navigate({ to: '/' });
+        addNotification('Access denied', 'error');
+        navigate({ to: '/login' });
       }
-    }, [unauthorized, navigate]);
+    }, [unauthorized, navigate, addNotification]);
 
     if (unauthorized) {
-      return null;
+      return <div className="p-4 text-center">Access denied</div>;
     }
     return <Component {...props} />;
   };


### PR DESCRIPTION
## Summary
- redirect unauthorized users to `/login` with notification and message
- add unit test for RoleGuard
- add testing dependencies

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run typecheck` *(fails: TS2339 and TS2322 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b573b2e88323b1a7d3449a225c08