### PR TITLE
Handle 204 responses in admin API client

### DIFF
--- a/AI-CHANGES.MD
+++ b/AI-CHANGES.MD
@@ -5,3 +5,4 @@
 - Generated frontend types from root specification.
 - Generated bot types (`bot_types.gen.py`) from root specification.
 - Documented specification update process in `README.md`.
+- Improved API client handling: return `null` for 204 responses, parse JSON error messages when possible and fall back to status text, and updated API modules to account for potential `null` results.

--- a/admin/src/api/audit.ts
+++ b/admin/src/api/audit.ts
@@ -33,5 +33,6 @@ export async function getAuditLogs(params: AuditQueryParams = {}): Promise<Audit
   if (params.offset !== undefined) search.set('offset', String(params.offset));
   const query = search.toString();
   const url = `/api/v1/audit/logs${query ? `?${query}` : ''}`;
-  return apiFetch<AuditLog[]>(url);
+  const res = await apiFetch<AuditLog[]>(url);
+  return res ?? [];
 }

--- a/admin/src/api/auth.ts
+++ b/admin/src/api/auth.ts
@@ -16,8 +16,9 @@ export interface LoginResponse {
  * the call will throw an error with the response message.
  */
 export async function login(req: LoginRequest): Promise<LoginResponse> {
-  return apiFetch<LoginResponse>('/api/v1/users/login', {
+  const res = await apiFetch<LoginResponse>('/api/v1/users/login', {
     method: 'POST',
     body: JSON.stringify(req),
   });
+  return res!;
 }

--- a/admin/src/api/bookings.ts
+++ b/admin/src/api/bookings.ts
@@ -27,7 +27,8 @@ export interface BookingCreate {
  * Fetch bookings for a specific event via GET /api/v1/events/{event_id}/bookings.
  */
 export async function getEventBookings(eventId: number): Promise<Booking[]> {
-  return apiFetch<Booking[]>(`/api/v1/events/${eventId}/bookings`);
+  const res = await apiFetch<Booking[]>(`/api/v1/events/${eventId}/bookings`);
+  return res ?? [];
 }
 
 /**
@@ -37,10 +38,11 @@ export async function createBooking(
   eventId: number,
   data: BookingCreate,
 ): Promise<Booking> {
-  return apiFetch<Booking>(`/api/v1/events/${eventId}/bookings`, {
+  const res = await apiFetch<Booking>(`/api/v1/events/${eventId}/bookings`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**
@@ -57,9 +59,10 @@ export async function deleteBooking(bookingId: number): Promise<void> {
  * Returns the updated booking.
  */
 export async function togglePayment(bookingId: number): Promise<Booking> {
-  return apiFetch<Booking>(`/api/v1/bookings/${bookingId}/toggle-payment`, {
+  const res = await apiFetch<Booking>(`/api/v1/bookings/${bookingId}/toggle-payment`, {
     method: 'POST',
   });
+  return res!;
 }
 
 /**
@@ -69,9 +72,10 @@ export async function togglePayment(bookingId: number): Promise<Booking> {
 export async function toggleAttendance(
   bookingId: number,
 ): Promise<Booking> {
-  return apiFetch<Booking>(`/api/v1/bookings/${bookingId}/toggle-attendance`, {
+  const res = await apiFetch<Booking>(`/api/v1/bookings/${bookingId}/toggle-attendance`, {
     method: 'POST',
   });
+  return res!;
 }
 
 /**
@@ -92,5 +96,6 @@ export interface WaitlistEntry {
 export async function getEventWaitlist(
   eventId: number,
 ): Promise<WaitlistEntry[]> {
-  return apiFetch<WaitlistEntry[]>(`/api/v1/events/${eventId}/waitlist`);
+  const res = await apiFetch<WaitlistEntry[]>(`/api/v1/events/${eventId}/waitlist`);
+  return res ?? [];
 }

--- a/admin/src/api/events.ts
+++ b/admin/src/api/events.ts
@@ -63,10 +63,11 @@ export interface EventUpdate {
  * Returns the created Event on success.
  */
 export async function createEvent(data: EventCreate): Promise<Event> {
-  return apiFetch<Event>('/api/v1/events/', {
+  const res = await apiFetch<Event>('/api/v1/events/', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**
@@ -77,10 +78,11 @@ export async function updateEvent(
   id: number,
   data: EventUpdate,
 ): Promise<Event> {
-  return apiFetch<Event>(`/api/v1/events/${id}`, {
+  const res = await apiFetch<Event>(`/api/v1/events/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**
@@ -105,10 +107,11 @@ export async function duplicateEvent(
   id: number,
   start_time: string,
 ): Promise<Event> {
-  return apiFetch<Event>(`/api/v1/events/${id}/duplicate`, {
+  const res = await apiFetch<Event>(`/api/v1/events/${id}/duplicate`, {
     method: 'POST',
     body: JSON.stringify({ start_time }),
   });
+  return res!;
 }
 
 /**
@@ -128,5 +131,6 @@ export async function getEvents(params: EventsQueryParams): Promise<Event[]> {
   if (params.date_to) query.set('date_to', params.date_to);
   const qs = query.toString();
   const url = qs ? `/api/v1/events/?${qs}` : '/api/v1/events/';
-  return apiFetch<Event[]>(url);
+  const res = await apiFetch<Event[]>(url);
+  return res ?? [];
 }

--- a/admin/src/api/faqs.ts
+++ b/admin/src/api/faqs.ts
@@ -49,23 +49,26 @@ export async function getFaqs(params: FaqQueryParams = {}): Promise<Faq[]> {
   if (params.order) search.set('order', params.order);
   const query = search.toString();
   const url = `/api/v1/faqs/${query ? `?${query}` : ''}`;
-  return apiFetch<Faq[]>(url);
+  const res = await apiFetch<Faq[]>(url);
+  return res ?? [];
 }
 
 /** Create a new FAQ entry. */
 export async function createFaq(data: FaqCreate): Promise<Faq> {
-  return apiFetch<Faq>('/api/v1/faqs/', {
+  const res = await apiFetch<Faq>('/api/v1/faqs/', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Update an existing FAQ entry by its ID. */
 export async function updateFaq(id: number, data: FaqUpdate): Promise<Faq> {
-  return apiFetch<Faq>(`/api/v1/faqs/${id}`, {
+  const res = await apiFetch<Faq>(`/api/v1/faqs/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Delete an FAQ entry. */

--- a/admin/src/api/mailings.ts
+++ b/admin/src/api/mailings.ts
@@ -69,28 +69,32 @@ export async function getMailings(params: MailingsQueryParams = {}): Promise<Mai
   if (params.order) search.set('order', params.order);
   const query = search.toString();
   const url = `/api/v1/mailings/${query ? `?${query}` : ''}`;
-  return apiFetch<Mailing[]>(url);
+  const res = await apiFetch<Mailing[]>(url);
+  return res ?? [];
 }
 
 /** Fetch details of a single mailing by ID. */
 export async function getMailing(id: number): Promise<Mailing> {
-  return apiFetch<Mailing>(`/api/v1/mailings/${id}`);
+  const res = await apiFetch<Mailing>(`/api/v1/mailings/${id}`);
+  return res!;
 }
 
 /** Create a new mailing.  Returns the created mailing. */
 export async function createMailing(data: MailingCreate): Promise<Mailing> {
-  return apiFetch<Mailing>('/api/v1/mailings/', {
+  const res = await apiFetch<Mailing>('/api/v1/mailings/', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Update an existing mailing.  Returns the updated mailing. */
 export async function updateMailing(id: number, data: MailingUpdate): Promise<Mailing> {
-  return apiFetch<Mailing>(`/api/v1/mailings/${id}`, {
+  const res = await apiFetch<Mailing>(`/api/v1/mailings/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Delete a mailing by its ID.  Returns void on success. */
@@ -102,9 +106,10 @@ export async function deleteMailing(id: number): Promise<void> {
 
 /** Trigger immediate sending of a mailing.  Returns the number of recipients. */
 export async function sendMailing(id: number): Promise<number> {
-  return apiFetch<number>(`/api/v1/mailings/${id}/send`, {
+  const res = await apiFetch<number>(`/api/v1/mailings/${id}/send`, {
     method: 'POST',
   });
+  return res ?? 0;
 }
 
 /** Retrieve delivery logs for a mailing.  Results may be paginated. */
@@ -117,5 +122,6 @@ export async function getMailingLogs(
   if (params.offset !== undefined) search.set('offset', String(params.offset));
   const query = search.toString();
   const url = `/api/v1/mailings/${id}/logs${query ? `?${query}` : ''}`;
-  return apiFetch<MailingLog[]>(url);
+  const res = await apiFetch<MailingLog[]>(url);
+  return res ?? [];
 }

--- a/admin/src/api/messages.ts
+++ b/admin/src/api/messages.ts
@@ -11,22 +11,25 @@ export type BotMessage = Record<string, unknown>;
 
 /** List all bot message templates.  Returns an array of objects. */
 export async function getMessages(): Promise<BotMessage[]> {
-  return apiFetch<BotMessage[]>('/api/v1/messages/');
+  const res = await apiFetch<BotMessage[]>('/api/v1/messages/');
+  return res ?? [];
 }
 
 /** Retrieve a single message template by key. */
 export async function getMessage(key: string): Promise<BotMessage> {
-  return apiFetch<BotMessage>(`/api/v1/messages/${encodeURIComponent(key)}`);
+  const res = await apiFetch<BotMessage>(`/api/v1/messages/${encodeURIComponent(key)}`);
+  return res!;
 }
 
 /** Create or update a message template.  The key is supplied in the
  * URL and the body contains the message content and optional
  * metadata (e.g. buttons). */
 export async function upsertMessage(key: string, data: BotMessage): Promise<BotMessage> {
-  return apiFetch<BotMessage>(`/api/v1/messages/${encodeURIComponent(key)}`, {
+  const res = await apiFetch<BotMessage>(`/api/v1/messages/${encodeURIComponent(key)}`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Delete a message template by key. */

--- a/admin/src/api/payments.ts
+++ b/admin/src/api/payments.ts
@@ -56,7 +56,8 @@ export async function getPayments(params: PaymentsQueryParams): Promise<Payment[
   if (params.offset !== undefined) query.set('offset', String(params.offset));
   const qs = query.toString();
   const url = qs ? `/api/v1/payments/?${qs}` : '/api/v1/payments/';
-  return apiFetch<Payment[]>(url);
+  const res = await apiFetch<Payment[]>(url);
+  return res ?? [];
 }
 
 /**

--- a/admin/src/api/reviews.ts
+++ b/admin/src/api/reviews.ts
@@ -35,7 +35,8 @@ export async function getReviews(params: ReviewsQueryParams = {}): Promise<Revie
   if (params.order) search.set('order', params.order);
   const query = search.toString();
   const url = `/api/v1/reviews${query ? `?${query}` : ''}`;
-  return apiFetch<Review[]>(url);
+  const res = await apiFetch<Review[]>(url);
+  return res ?? [];
 }
 
 /** Delete a review by its ID. */
@@ -47,8 +48,9 @@ export async function deleteReview(id: number): Promise<void> {
 
 /** Approve or reject a review.  Returns the updated review. */
 export async function moderateReview(id: number, approved: boolean): Promise<Review> {
-  return apiFetch<Review>(`/api/v1/reviews/${id}/moderate`, {
+  const res = await apiFetch<Review>(`/api/v1/reviews/${id}/moderate`, {
     method: 'PUT',
     body: JSON.stringify({ approved }),
   });
+  return res!;
 }

--- a/admin/src/api/roles.ts
+++ b/admin/src/api/roles.ts
@@ -41,7 +41,8 @@ export interface RoleUpdate {
  * support pagination.
  */
 export async function getRoles(): Promise<Role[]> {
-  return apiFetch<Role[]>('/api/v1/roles/');
+  const res = await apiFetch<Role[]>('/api/v1/roles/');
+  return res ?? [];
 }
 
 /**
@@ -49,10 +50,11 @@ export async function getRoles(): Promise<Role[]> {
  * role.  Only super administrators may create roles.
  */
 export async function createRole(data: RoleCreate): Promise<Role> {
-  return apiFetch<Role>('/api/v1/roles/', {
+  const res = await apiFetch<Role>('/api/v1/roles/', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**
@@ -60,10 +62,11 @@ export async function createRole(data: RoleCreate): Promise<Role> {
  * updated role.  Only super administrators may modify roles.
  */
 export async function updateRole(id: number, data: RoleUpdate): Promise<Role> {
-  return apiFetch<Role>(`/api/v1/roles/${id}`, {
+  const res = await apiFetch<Role>(`/api/v1/roles/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**

--- a/admin/src/api/settings.ts
+++ b/admin/src/api/settings.ts
@@ -13,19 +13,22 @@ export interface Setting {
 
 /** Fetch all settings.  Only super administrators can access this endpoint. */
 export async function getSettings(): Promise<Setting[]> {
-  return apiFetch<Setting[]>('/api/v1/settings/');
+  const res = await apiFetch<Setting[]>('/api/v1/settings/');
+  return res ?? [];
 }
 
 /** Retrieve a specific setting by key. */
 export async function getSetting(key: string): Promise<Setting> {
-  return apiFetch<Setting>(`/api/v1/settings/${encodeURIComponent(key)}`);
+  const res = await apiFetch<Setting>(`/api/v1/settings/${encodeURIComponent(key)}`);
+  return res!;
 }
 
 /** Upsert (create or update) a setting.  Provide the new value and its
  * type.  Supported types include 'string', 'int', 'float' and 'bool'. */
 export async function upsertSetting(key: string, value: unknown, type: string): Promise<Setting> {
-  return apiFetch<Setting>(`/api/v1/settings/${encodeURIComponent(key)}`, {
+  const res = await apiFetch<Setting>(`/api/v1/settings/${encodeURIComponent(key)}`, {
     method: 'POST',
     body: JSON.stringify({ value, type }),
   });
+  return res!;
 }

--- a/admin/src/api/statistics.ts
+++ b/admin/src/api/statistics.ts
@@ -26,5 +26,6 @@ export interface StatisticsOverview {
  * propagation.  Returns a record of counts keyed by metric name.
  */
 export async function getStatisticsOverview(): Promise<StatisticsOverview> {
-  return apiFetch<StatisticsOverview>('/api/v1/statistics/overview');
+  const res = await apiFetch<StatisticsOverview>('/api/v1/statistics/overview');
+  return res!;
 }

--- a/admin/src/api/support.ts
+++ b/admin/src/api/support.ts
@@ -68,15 +68,17 @@ export async function getTickets(params: TicketsQueryParams = {}): Promise<Suppo
   if (params.order) search.set('order', params.order);
   const query = search.toString();
   const url = `/api/v1/support/tickets${query ? `?${query}` : ''}`;
-  return apiFetch<SupportTicket[]>(url);
+  const res = await apiFetch<SupportTicket[]>(url);
+  return res ?? [];
 }
 
 /** Create a new support ticket. */
 export async function createTicket(data: SupportTicketCreate): Promise<SupportTicket> {
-  return apiFetch<SupportTicket>('/api/v1/support/tickets', {
+  const res = await apiFetch<SupportTicket>('/api/v1/support/tickets', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Delete a support ticket.  Only administrators can delete tickets. */
@@ -88,7 +90,8 @@ export async function deleteTicket(id: number): Promise<void> {
 
 /** Retrieve a ticket along with its message thread. */
 export async function getTicketWithMessages(id: number): Promise<TicketWithMessages> {
-  return apiFetch<TicketWithMessages>(`/api/v1/support/tickets/${id}`);
+  const res = await apiFetch<TicketWithMessages>(`/api/v1/support/tickets/${id}`);
+  return res!;
 }
 
 /** Reply to a support ticket.  Returns the created message. */
@@ -96,16 +99,18 @@ export async function replyToTicket(
   id: number,
   data: { content: string; attachments?: string[] | null },
 ): Promise<SupportMessage> {
-  return apiFetch<SupportMessage>(`/api/v1/support/tickets/${id}/reply`, {
+  const res = await apiFetch<SupportMessage>(`/api/v1/support/tickets/${id}/reply`, {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /** Update the status of a support ticket. */
 export async function updateTicketStatus(id: number, status: string): Promise<SupportTicket> {
-  return apiFetch<SupportTicket>(`/api/v1/support/tickets/${id}/status`, {
+  const res = await apiFetch<SupportTicket>(`/api/v1/support/tickets/${id}/status`, {
     method: 'PUT',
     body: JSON.stringify({ status }),
   });
+  return res!;
 }

--- a/admin/src/api/users.ts
+++ b/admin/src/api/users.ts
@@ -54,7 +54,8 @@ export interface UserUpdate {
  * parameters for limit/offset and forward them accordingly.
  */
 export async function getUsers(): Promise<User[]> {
-  return apiFetch<User[]>('/api/v1/users/');
+  const res = await apiFetch<User[]>('/api/v1/users/');
+  return res ?? [];
 }
 
 /**
@@ -64,10 +65,11 @@ export async function getUsers(): Promise<User[]> {
  * will surface through the apiFetch helper.
  */
 export async function createUser(data: UserCreate): Promise<User> {
-  return apiFetch<User>('/api/v1/users/', {
+  const res = await apiFetch<User>('/api/v1/users/', {
     method: 'POST',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**
@@ -76,10 +78,11 @@ export async function createUser(data: UserCreate): Promise<User> {
  * will be updated; undefined values are omitted entirely.
  */
 export async function updateUser(id: number, data: UserUpdate): Promise<User> {
-  return apiFetch<User>(`/api/v1/users/${id}`, {
+  const res = await apiFetch<User>(`/api/v1/users/${id}`, {
     method: 'PUT',
     body: JSON.stringify(data),
   });
+  return res!;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Return `null` for 204 responses in `apiFetch` and improve error parsing
- Adjust admin API modules to handle potential `null` data
- Document change in AI-CHANGES

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck` *(fails: Property 'env' does not exist on type 'ImportMeta' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b57f1e7c8323abf98a81b6cbbe77